### PR TITLE
Feature/private routes

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,6 +19,7 @@ import TeacherTaskViewerPage from "./pages/teacherTaskViewer";
 
 // Context
 import { AuthProvider } from "./context/auth";
+import PrivateRoute from "./components/PrivateRoute";
 
 function App() {
 	return (
@@ -29,28 +30,36 @@ function App() {
 						<Navigation />
 						<div>
 							<Switch>
+								<PrivateRoute
+									path="/teacherTasks"
+									component={TeacherTasksPage}
+									adminRoute={true}
+								/>
+
+								<PrivateRoute
+									path="/teacherTaskViewer"
+									component={TeacherTaskViewerPage}
+									adminRoute={true}
+								/>
+
+								<PrivateRoute
+									path="/teacherTaskEditor"
+									component={TeacherTaskEditorPage}
+									adminRoute={true}
+								/>
+
+								<PrivateRoute
+									path="/profile"
+									adminRoute={false}
+									component={ProfilePage}
+								/>
+
 								<Route path="/signup">
 									<SignupPage />
 								</Route>
 
 								<Route path="/login">
 									<LoginPage />
-								</Route>
-
-								<Route path="/teacherTasks">
-									<TeacherTasksPage />
-								</Route>
-
-								<Route path="/teacherTaskViewer">
-									<TeacherTaskViewerPage />
-								</Route>
-
-								<Route path="/teacherTaskEditor">
-									<TeacherTaskEditorPage />
-								</Route>
-
-								<Route path="/profile">
-									<ProfilePage />
 								</Route>
 
 								<Route path="/">

--- a/frontend/src/components/PrivateRoute/index.js
+++ b/frontend/src/components/PrivateRoute/index.js
@@ -1,0 +1,30 @@
+import React from "react";
+import { AuthContext } from "../../context/auth";
+import { Route, Redirect } from "react-router-dom";
+
+const PrivateRoute = ({
+	component: Component,
+	adminRoute = false,
+	...routeProps
+}) => {
+	const { authState } = React.useContext(AuthContext);
+
+	const isLogin = () => {
+		if (adminRoute) {
+			return authState.authenticated && authState.user.claims.teacher;
+		} else {
+			return authState.authenticated;
+		}
+	};
+
+	return (
+		<Route
+			{...routeProps}
+			render={(props) =>
+				isLogin() ? <Component {...props} /> : <Redirect to="/login" />
+			}
+		/>
+	);
+};
+
+export default PrivateRoute;

--- a/frontend/src/components/navigation/index.js
+++ b/frontend/src/components/navigation/index.js
@@ -124,9 +124,6 @@ function Navigation() {
 	const { authState, setAuthState } = React.useContext(AuthContext);
 	let navComp;
 
-	console.log(authState);
-
-
 	const handleSignOut = () => {
 		setAuthState(null);
 	};


### PR DESCRIPTION
Added a PrivateRoute component that can be used in the react-router to restrict access to paths, if a user is not authenticated or an admin user (configurable) they will be redirected to the login page.

The PrivateRouter can be used like this:
```js
<PrivateRoute
    path="/teacherTaskViewer"
    component={TeacherTaskViewerPage}
    adminRoute={true}
/>
```
This component will accept all default react router route props, the `adminRoute` prop is a toggle on whether to check if the user has an admin claim or not.