### PR TITLE
Feature/api helpers

### DIFF
--- a/frontend/src/components/navigation/index.js
+++ b/frontend/src/components/navigation/index.js
@@ -51,7 +51,12 @@ const buildGuestNav = (classes, signOutFunc) => {
 				>
 					Sign Up
 				</Button>
-				<Button color="inherit" component={Link} onClick={signOutFunc} to="/login">
+				<Button
+					color="inherit"
+					component={Link}
+					onClick={signOutFunc}
+					to="/login"
+				>
 					Login
 				</Button>
 			</Toolbar>
@@ -103,6 +108,14 @@ const buildTeacherNav = (classes, signOutFunc) => {
 						Quantum Circuit Simulator Group 2 - Teacher
 					</Typography>
 				</Box>
+				<Button
+					className={classes.signup}
+					color="inherit"
+					component={Link}
+					to="/profile"
+				>
+					Profile
+				</Button>
 				<Button
 					className={classes.signup}
 					color="inherit"

--- a/frontend/src/components/profile/index.js
+++ b/frontend/src/components/profile/index.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React from "react";
 import ProfileRow from "./profileRow";
 import { makeStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
@@ -7,41 +7,50 @@ import Box from "@material-ui/core/Box";
 import BoxedSpace from "../common/boxedSpace";
 
 const useStyles = makeStyles((theme) => ({
-    row: {
-        marginTop: theme.spacing(2),
-        marginBottom: theme.spacing(2)
-    },
-    divider: {
-        width: "100%",
-        borderBottom: "solid 1px rgba(0, 0, 0, 0.07)"
-    },
+	row: {
+		marginTop: theme.spacing(2),
+		marginBottom: theme.spacing(2),
+	},
+	divider: {
+		width: "100%",
+		borderBottom: "solid 1px rgba(0, 0, 0, 0.07)",
+	},
 }));
 
-export default function Profile () {
-    const classes = useStyles();
+export default function Profile(props) {
+	const classes = useStyles();
+	const { userData } = props;
 
-    function fetchProfile() {
-        // TODO: Get profile data from the backend here.
-    }
+	const divider = <Box className={classes.divider} />;
 
-    let divider = (<Box className={classes.divider}/>);
+	return (
+		<Box m={3}>
+			<Container maxWidth="md">
+				<Box textAlign="left" ml={3} my={1}>
+					<Typography variant="h4">Profile</Typography>
+				</Box>
 
-    return (
-        <Box m={3}>
-            <Container maxWidth="md">
-
-                <Box textAlign="left" ml={3} my={1}>
-                    <Typography variant="h4">Profile</Typography>
-                </Box>
-
-                <BoxedSpace>
-                    <ProfileRow className={classes.row} title="Name" value="Sample gazooie" editable/>
-                    {divider}
-                    <ProfileRow className={classes.row} title="Student ID" value="121341"/>
-                    {divider}
-                    <ProfileRow className={classes.row} title="Email" value="sample@gmail.com" editable/>
-                </BoxedSpace>
-            </Container>
-        </Box>
-    );
+				{userData ? (
+					<BoxedSpace>
+						<ProfileRow
+							className={classes.row}
+							title="Name"
+							value={userData.displayName}
+							editable
+						/>
+						{divider}
+						<ProfileRow
+							className={classes.row}
+							title="Email"
+							value={userData.email}
+							editable
+						/>
+					</BoxedSpace>
+				) : (
+					// TODO: Add some kind of spinner here to show the page is still loading
+					<p>Loading profile</p>
+				)}
+			</Container>
+		</Box>
+	);
 }

--- a/frontend/src/helpers/api/circuit.js
+++ b/frontend/src/helpers/api/circuit.js
@@ -1,0 +1,57 @@
+import axios from "axios";
+import { API_HOST } from ".";
+
+export const solveCircuit = async (circuitData) => {
+	const res = await axios.post(`http://${API_HOST}/circuit/solve`, circuitData);
+	return res;
+};
+
+export const getAllCircuits = async (idToken, userId) => {
+	const res = await axios.get(`http://${API_HOST}/user/${userId}/circuit`, {
+		headers: { Authorization: `Bearer ${idToken}` },
+	});
+	return res;
+};
+
+export const getSingleCircuit = async (idToken, userId, circuitId) => {
+	const res = await axios.get(
+		`http://${API_HOST}/user/${userId}/circuit/${circuitId}`,
+		{
+			headers: { Authorization: `Bearer ${idToken}` },
+		}
+	);
+	return res;
+};
+
+export const createCircuit = async (idToken, circuitData) => {
+	const res = await axios.post(`http://${API_HOST}/user/circuit`, circuitData, {
+		headers: { Authorization: `Bearer ${idToken}` },
+	});
+	return res;
+};
+
+export const updateCircuit = async (
+	idToken,
+	userId,
+	circuitId,
+	circuitData
+) => {
+	const res = await axios.post(
+		`http://${API_HOST}/user/${userId}/circuit/${circuitId}`,
+		circuitData,
+		{
+			headers: { Authorization: `Bearer ${idToken}` },
+		}
+	);
+	return res;
+};
+
+export const deleteCircuit = async (idToken, userId, circuitId) => {
+	const res = await axios.delete(
+		`http://${API_HOST}/user/${userId}/circuit/${circuitId}`,
+		{
+			headers: { Authorization: `Bearer ${idToken}` },
+		}
+	);
+	return res;
+};

--- a/frontend/src/helpers/api/index.js
+++ b/frontend/src/helpers/api/index.js
@@ -1,0 +1,55 @@
+import { getUser, createUser, updateUser, deleteUser } from "./user";
+import {
+	solveCircuit,
+	getAllCircuits,
+	createCircuit,
+	getSingleCircuit,
+	updateCircuit,
+	deleteCircuit,
+} from "./circuit";
+
+export const API_HOST = "localhost:4000";
+
+export default {
+	auth: {
+		login: () => {},
+	},
+	user: {
+		create: createUser,
+		get: getUser,
+		update: updateUser,
+		delete: deleteUser,
+		circuit: {
+			create: createCircuit,
+			getAll: getAllCircuits,
+			getSingle: getSingleCircuit,
+			update: updateCircuit,
+			delete: deleteCircuit,
+		},
+	},
+	circuit: {
+		solve: solveCircuit,
+	},
+	task: {
+		getAll: () => {},
+		getSingle: () => {},
+		submission: {
+			get: () => {},
+			update: () => {},
+			delete: () => {},
+		},
+	},
+	admin: {
+		tasks: {
+			create: () => {},
+			getAll: () => {},
+			getSingle: () => {},
+			update: () => {},
+			delete: () => {},
+			submission: {
+				getAll: () => {},
+				update: () => {},
+			},
+		},
+	},
+};

--- a/frontend/src/helpers/api/index.js
+++ b/frontend/src/helpers/api/index.js
@@ -7,13 +7,26 @@ import {
 	updateCircuit,
 	deleteCircuit,
 } from "./circuit";
+import {
+	getAllTasks,
+	getSingleTask,
+	createTask,
+	getAllTasksAdmin,
+	getSingleTasksAdmin,
+	updateTask,
+	deleteTask,
+} from "./task";
+import {
+	getSubmission,
+	updateSubmission,
+	deleteSubmission,
+	getAllSubmissionsAdmin,
+	updateSubmissionAdmin,
+} from "./submission";
 
 export const API_HOST = "localhost:4000";
 
 export default {
-	auth: {
-		login: () => {},
-	},
 	user: {
 		create: createUser,
 		get: getUser,
@@ -31,24 +44,24 @@ export default {
 		solve: solveCircuit,
 	},
 	task: {
-		getAll: () => {},
-		getSingle: () => {},
+		getAll: getAllTasks,
+		getSingle: getSingleTask,
 		submission: {
-			get: () => {},
-			update: () => {},
-			delete: () => {},
+			get: getSubmission,
+			update: updateSubmission,
+			delete: deleteSubmission,
 		},
 	},
 	admin: {
 		tasks: {
-			create: () => {},
-			getAll: () => {},
-			getSingle: () => {},
-			update: () => {},
-			delete: () => {},
+			create: createTask,
+			getAll: getAllTasksAdmin,
+			getSingle: getSingleTasksAdmin,
+			update: updateTask,
+			delete: deleteTask,
 			submission: {
-				getAll: () => {},
-				update: () => {},
+				getAll: getAllSubmissionsAdmin,
+				update: updateSubmissionAdmin,
 			},
 		},
 	},

--- a/frontend/src/helpers/api/submission.js
+++ b/frontend/src/helpers/api/submission.js
@@ -1,0 +1,48 @@
+import axios from "axios";
+import { API_HOST } from ".";
+
+export const getSubmission = async (idToken, taskId) => {
+	const res = await axios.get(`http://${API_HOST}/task/${taskId}/submission`, {
+		headers: { Authorization: `Bearer ${idToken}` },
+	});
+	return res;
+};
+
+export const updateSubmission = async (idToken, taskId, circuitData) => {
+	const res = await axios.post(
+		`http://${API_HOST}/task/${taskId}/submission/update`,
+		circuitData,
+		{
+			headers: { Authorization: `Bearer ${idToken}` },
+		}
+	);
+	return res;
+};
+
+export const deleteSubmission = async (idToken, taskId) => {
+	const res = await axios.delete(
+		`http://${API_HOST}/task/${taskId}/submission/update`,
+		{
+			headers: { Authorization: `Bearer ${idToken}` },
+		}
+	);
+	return res;
+};
+
+export const getAllSubmissionsAdmin = async (idToken, taskId) => {
+	const res = await axios.get(`http://${API_HOST}/admin/task/${taskId}/submission`, {
+		headers: { Authorization: `Bearer ${idToken}` },
+	});
+	return res;
+};
+
+export const updateSubmissionAdmin = async (idToken, taskId, resultsData) => {
+	const res = await axios.post(
+		`http://${API_HOST}/admin/task/${taskId}/submission/update`,
+		resultsData,
+		{
+			headers: { Authorization: `Bearer ${idToken}` },
+		}
+	);
+	return res;
+};

--- a/frontend/src/helpers/api/task.js
+++ b/frontend/src/helpers/api/task.js
@@ -1,0 +1,62 @@
+import axios from "axios";
+import { API_HOST } from ".";
+
+export const getAllTasks = async (idToken) => {
+	const res = await axios.get(`http://${API_HOST}/task`, {
+		headers: { Authorization: `Bearer ${idToken}` },
+	});
+	return res;
+};
+
+export const getSingleTask = async (idToken, taskId) => {
+	const res = await axios.get(`http://${API_HOST}/task/${taskId}`, {
+		headers: { Authorization: `Bearer ${idToken}` },
+	});
+	return res;
+};
+
+export const createTask = async (idToken, taskData) => {
+	const res = await axios.post(
+		`http://${API_HOST}/admin/task/create`,
+		taskData,
+		{
+			headers: { Authorization: `Bearer ${idToken}` },
+		}
+	);
+	return res;
+};
+
+export const getAllTasksAdmin = async (idToken) => {
+	const res = await axios.get(`http://${API_HOST}/admin/task`, {
+		headers: { Authorization: `Bearer ${idToken}` },
+	});
+	return res;
+};
+
+export const getSingleTasksAdmin = async (idToken, taskId) => {
+	const res = await axios.get(`http://${API_HOST}/admin/task/${taskId}`, {
+		headers: { Authorization: `Bearer ${idToken}` },
+	});
+	return res;
+};
+
+export const updateTask = async (idToken, taskId, taskData) => {
+	const res = await axios.post(
+		`http://${API_HOST}/admin/task/${taskId}/update`,
+		taskData,
+		{
+			headers: { Authorization: `Bearer ${idToken}` },
+		}
+	);
+	return res;
+};
+
+export const deleteTask = async (idToken, taskId) => {
+	const res = await axios.post(
+		`http://${API_HOST}/admin/task/${taskId}/update`,
+		{
+			headers: { Authorization: `Bearer ${idToken}` },
+		}
+	);
+	return res;
+};

--- a/frontend/src/helpers/api/user.js
+++ b/frontend/src/helpers/api/user.js
@@ -1,0 +1,32 @@
+import axios from "axios";
+import { API_HOST } from ".";
+
+export const getUser = async (idToken, userId) => {
+	const res = await axios.get(`http://${API_HOST}/user/${userId}`, {
+		headers: { Authorization: `Bearer ${idToken}` },
+	});
+	return res;
+};
+
+export const createUser = async (userData) => {
+	const res = await axios.post(`http://${API_HOST}/user/create`, userData);
+	return res;
+};
+
+export const updateUser = async (idToken, userId, userData) => {
+	const res = await axios.post(
+		`http://${API_HOST}/user/${userId}/update`,
+		userData,
+		{
+			headers: { Authorization: `Bearer ${idToken}` },
+		}
+	);
+	return res;
+};
+
+export const deleteUser = async (idToken, userId) => {
+	const res = await axios.delete(`http://${API_HOST}/user/${userId}/update`, {
+		headers: { Authorization: `Bearer ${idToken}` },
+	});
+	return res;
+};

--- a/frontend/src/pages/profile/index.js
+++ b/frontend/src/pages/profile/index.js
@@ -1,18 +1,30 @@
-import React from "react";
-import {Box, Typography} from "@material-ui/core";
+import React, { useContext } from "react";
+import { Box, Typography } from "@material-ui/core";
 import Profile from "../../components/profile";
+import api from "../../helpers/api";
+import { AuthContext } from "../../context/auth";
 
 export default class ProfilePage extends React.Component {
+	static contextType = AuthContext;
 
-    constructor(props) {
-        super(props);
-    }
+	constructor(props) {
+		super(props);
+		this.state = {
+			userData: undefined,
+		};
+	}
 
-    render() {
-        return (
-            <Box>
-                <Profile />
-            </Box>
-        )
-    }
+	async componentDidMount() {
+		const { idToken, uid } = this.context.authState.user;
+		const userData = (await api.user.get(idToken, uid)).data.data;
+		this.setState({ userData });
+	}
+
+	render() {
+		return (
+			<Box>
+				<Profile userData={this.state.userData} />
+			</Box>
+		);
+	}
 }


### PR DESCRIPTION
Added an API helper for all of the current API routes as easy callable functions. The example below will use the API to fetch user details. Note the use of the global auth context to access common information for API calls like the users `uid` and the users current `idToken`.

```js
import React from "react"
import { AuthContext } from "./context/auth"
import api from "./helpers/api"

const {authState, setAuthState} = React.useContext(AuthContext)
const { idToken, uid } = authState.user;
const userData = (await api.user.get(idToken, uid)).data.data;
```

You can also check out this `Profile` page file for a pattern on how to use authenticated API routes with information from the global auth context.